### PR TITLE
Grunt tasks don't fail when compilation fails

### DIFF
--- a/tasks/latex.js
+++ b/tasks/latex.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
         success = true;
       }
 
-      cb();
+      cb(success ? null : new Error("Compilation failed with error code: "+code));
     });
     child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stderr);


### PR DESCRIPTION
I passed the output of success on to the grunt task callback so that the tasks will stop if LaTeX encounters a fatal error. I assume that was the purpose of the `success` variable and it just never got passed.

I tried sending the value of `success` directly, but strangely it wouldn't work.